### PR TITLE
added dynamic test-port

### DIFF
--- a/duell/build/plugin/platform/PlatformBuild.hx
+++ b/duell/build/plugin/platform/PlatformBuild.hx
@@ -415,7 +415,12 @@ class PlatformBuild
 		/// RUN THE LISTENER
 		try
 		{
-			// TODO: Find a better/central place for the hardcoded fallback port 8181 ?
+			/**
+            * TODO: Find a better/central place for the hardcoded fallback port 8181
+            *       which is intended fall back on if the duell-tool's configuration
+            *       does not provide the TEST_PORT property (backward-compatibility).
+            *       Remove eventually...
+            **/
 			var testPort:Int = untyped Configuration.getData().TEST_PORT == null ?
 				8181 : Configuration.getData().TEST_PORT;
 

--- a/duell/build/plugin/platform/PlatformBuild.hx
+++ b/duell/build/plugin/platform/PlatformBuild.hx
@@ -419,7 +419,7 @@ class PlatformBuild
 			var testPort:Int = untyped Configuration.getData().TEST_PORT == null ?
 				8181 : Configuration.getData().TEST_PORT;
 
-			TestHelper.runListenerServer(300, 8181, fullTestResultPath);
+			TestHelper.runListenerServer(300, testPort, fullTestResultPath);
 		}
 		catch (e:Dynamic)
 		{

--- a/duell/build/plugin/platform/PlatformBuild.hx
+++ b/duell/build/plugin/platform/PlatformBuild.hx
@@ -415,6 +415,10 @@ class PlatformBuild
 		/// RUN THE LISTENER
 		try
 		{
+			// TODO: Find a better/central place for the hardcoded fallback port 8181 ?
+			var testPort:Int = untyped Configuration.getData().TEST_PORT == null ?
+				8181 : Configuration.getData().TEST_PORT;
+
 			TestHelper.runListenerServer(300, 8181, fullTestResultPath);
 		}
 		catch (e:Dynamic)


### PR DESCRIPTION
Hello SGF team,

in terms of making the earlier pull request for the duell-tool work I'd like you the review and add this branch to the duellbuildhtml5 library by chance. It would help to have two clients running on one virtual machine, both using different ports to not interfere each other.

Thanks,
Fabian
